### PR TITLE
Increases memory limit of scripts from 64k to 128k.  This is due to…

### DIFF
--- a/CompilerRuntime/InWorldz.Phlox/Types/LSLList.cs
+++ b/CompilerRuntime/InWorldz.Phlox/Types/LSLList.cs
@@ -82,7 +82,7 @@ namespace InWorldz.Phlox.Types
         private void CheckMemorySize()
         {
             //TODO: this sucks, refactor it should reference max memory from somewhere else
-            const int MAX_MEMORY = 65536;
+            const int MAX_MEMORY = 0x20000;
             if (_memorySize > MAX_MEMORY)
             {
                 throw new CheckException("Out of memory");

--- a/CompilerRuntime/InWorldz.Phlox/VM/MemoryInfo.cs
+++ b/CompilerRuntime/InWorldz.Phlox/VM/MemoryInfo.cs
@@ -17,7 +17,7 @@ namespace InWorldz.Phlox.VM
         /// <summary>
         /// Maximum memory in bytes allowed for all allocations
         /// </summary>
-        public const int MAX_MEMORY = 65536;
+        public const int MAX_MEMORY = 0x20000;
 
         [ProtoMember(1)]
         public int MemoryUsed;


### PR DESCRIPTION
…the possibility that some (large) scripts from Second Life may not function under Phlox, due to strings being utf-16 instead of utf-8.
